### PR TITLE
Infer file from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,12 @@ Use the following code.
 
 ```ts
 import { scaffold } from "https://deno.land/x/skaffe@v1.0.0/mod.ts";
-import { join } from "https://deno.land/std@0.123.0/path/mod.ts";
 
 const thisFile = import.meta.url;
-const targetFile = join(Deno.cwd(), "target-file.ts");
+const targetDirectory = Deno.cwd(); // using a dir will infer the file name
 
 // Will copy this very source file into the working directory
-await scaffold(thisFile, targetFile);
+await scaffold(thisFile, targetDirectory);
 ```
 
 ## Node Example
@@ -39,13 +38,12 @@ and use the following code.
 
 ```ts
 const { scaffold } = require("skaffe");
-const { join } = require("path");
 
 const thisFile = __filename;
-const targetFile = join(process.cwd(), "target-file.js");
+const targetDirectory = process.cwd(); // using a dir will infer the file name
 
 // Will copy this very source file into the working directory
-scaffold(thisFile, targetFile);
+scaffold(thisFile, targetDirectory);
 ```
 
 ## Why?
@@ -66,5 +64,5 @@ and Node, and let `skaffe` do the nasty part.
 
 ## What's in a Name?
 
-The word _skaffe_ is Norwegian and means _provide_.
-It also looks similar to the prefix of _scaffolding_.
+The word _skaffe_ is Norwegian and means _provide_. It also looks similar to the
+prefix of _scaffolding_.

--- a/example.ts
+++ b/example.ts
@@ -1,8 +1,7 @@
 import { scaffold } from "https://deno.land/x/skaffe@v1.0.0/mod.ts";
-import { join } from "https://deno.land/std@0.123.0/path/mod.ts";
 
 const thisFile = import.meta.url;
-const targetFile = join(Deno.cwd(), "example.ts");
+const targetDirectory = Deno.cwd(); // using a dir will infer the file name
 
 // Will copy this very source file into the working directory
-await scaffold(thisFile, targetFile);
+await scaffold(thisFile, targetDirectory);

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -3,6 +3,9 @@ import {
   readerFromIterable,
 } from "https://deno.land/std@0.123.0/streams/mod.ts";
 
+export const { stat } = Deno;
+export { basename, join } from "https://deno.land/std@0.123.0/path/mod.ts";
+
 export async function writeData(
   target: string,
   data: AsyncIterable<Uint8Array>,

--- a/src/platform.deno.ts
+++ b/src/platform.deno.ts
@@ -3,8 +3,9 @@ import {
   readerFromIterable,
 } from "https://deno.land/std@0.123.0/streams/mod.ts";
 
-export const { stat } = Deno;
 export { basename, join } from "https://deno.land/std@0.123.0/path/mod.ts";
+export const isDirectory = (path: string) =>
+  Deno.stat(path).then((info) => info.isDirectory);
 
 export async function writeData(
   target: string,

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -1,6 +1,9 @@
 import { createWriteStream } from "fs";
 import { Readable } from "stream";
 
+export { lstat as stat } from "fs";
+export { basename, join } from "path";
+
 export async function writeData(
   target: string,
   data: AsyncIterable<Uint8Array>,

--- a/src/platform.node.ts
+++ b/src/platform.node.ts
@@ -1,8 +1,10 @@
 import { createWriteStream } from "fs";
 import { Readable } from "stream";
+import { lstat } from "fs/promises";
 
-export { lstat as stat } from "fs";
 export { basename, join } from "path";
+export const isDirectory = (path: string) =>
+  lstat(path).then((info) => info.isDirectory());
 
 export async function writeData(
   target: string,

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -1,4 +1,4 @@
-import { basename, join, stat, writeData } from "./platform.deno.ts";
+import { basename, isDirectory, join, writeData } from "./platform.deno.ts";
 
 export async function scaffold(source: string | URL, target: string) {
   const file = await toFile(source, target);
@@ -24,8 +24,7 @@ export async function toFile(
   let result = targetDirectoryOrFile;
   try {
     // If the given target is an existing directory ...
-    const { isDirectory } = await stat(targetDirectoryOrFile);
-    if (isDirectory) {
+    if (await isDirectory(targetDirectoryOrFile)) {
       // ... use the source file name in the directory.
       const path = typeof sourceFile === "string"
         ? sourceFile

--- a/src/scaffold.ts
+++ b/src/scaffold.ts
@@ -1,8 +1,9 @@
-import { writeData } from "./platform.deno.ts";
+import { basename, join, stat, writeData } from "./platform.deno.ts";
 
 export async function scaffold(source: string | URL, target: string) {
+  const file = await toFile(source, target);
   const data: AsyncIterable<Uint8Array> = await getFile(source);
-  await writeData(target, data);
+  await writeData(file, data);
 }
 
 export async function getFile(
@@ -14,4 +15,25 @@ export async function getFile(
     throw new Error(`Resource at ${source} could not be accessed!`);
   }
   return data;
+}
+
+export async function toFile(
+  sourceFile: string | URL,
+  targetDirectoryOrFile: string,
+): Promise<string> {
+  let result = targetDirectoryOrFile;
+  try {
+    // If the given target is an existing directory ...
+    const { isDirectory } = await stat(targetDirectoryOrFile);
+    if (isDirectory) {
+      // ... use the source file name in the directory.
+      const path = typeof sourceFile === "string"
+        ? sourceFile
+        : sourceFile.pathname;
+      result = join(targetDirectoryOrFile, basename(path));
+    }
+  } catch {
+    // Failed to stat, do not infer filename
+  }
+  return result;
 }

--- a/src/shim.node.ts
+++ b/src/shim.node.ts
@@ -1,4 +1,6 @@
 import { createReadStream } from "fs";
+import { URL } from "url";
+export { URL };
 
 interface FetchResult {
   body: AsyncIterable<Uint8Array>;


### PR DESCRIPTION
Allows people to pass a directory as the target path. Will then infer the file name from the source path, and join it with the given target directory.